### PR TITLE
FISH-6976: adding option to exclude java packages

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -1,5 +1,6 @@
 -exportcontents: \
     org.eclipse.microprofile.*
+-noimportjava: true
 Import-Package: jakarta.enterprise.util.*;resolution:=optional, jakarta.inject.*;resolution:=optional, jakarta.interceptor.*;resolution:=optional, *
 Bundle-SymbolicName: org.eclipse.microprofile.metrics
 Bundle-Name: MicroProfile Metrics Bundle


### PR DESCRIPTION
It was needed to fork the last version of metrics and add the following option to exclude java packages for the osgi manifest file. If those are not excluded then the server start to fail with osgi issues