### PR TITLE
FISH-7433: upgrading metrics version

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -1,5 +1,6 @@
 -exportcontents: \
     org.eclipse.microprofile.*
+-noimportjava: true
 Import-Package: jakarta.enterprise.util.*;resolution:=optional, jakarta.inject.*;resolution:=optional, jakarta.interceptor.*;resolution:=optional, *
 Bundle-SymbolicName: org.eclipse.microprofile.metrics
 Bundle-Name: MicroProfile Metrics Bundle

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,12 +19,16 @@
     <parent>
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>5.1.0-RC1</version>
+        <version>5.1.0-RC1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-metrics-api</artifactId>
     <name>MicroProfile Metrics API</name>
     <description>MicroProfile Metrics :: API</description>
+
+    <properties>
+        <bnd.baseline.continue.on.error>true</bnd.baseline.continue.on.error>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -44,5 +48,5 @@
             <artifactId>org.osgi.annotation.versioning</artifactId>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.eclipse.microprofile.metrics</groupId>
     <artifactId>microprofile-metrics-parent</artifactId>
-    <version>5.1.0-RC1</version>
+    <version>5.1.0-RC1.payara-p1</version>
     <packaging>pom</packaging>
     <name>MicroProfile Metrics</name>
     <description>Eclipse MicroProfile Metrics Feature :: Parent POM</description>
@@ -57,7 +57,7 @@
         <url>https://github.com/eclipse/microprofile-metrics</url>
         <connection>scm:git:https://github.com/eclipse/microprofile-metrics.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse/microprofile-metrics.git</developerConnection>
-        <tag>5.1.0-RC1</tag>
+        <tag>5.1.0-RC1.payara-p1</tag>
     </scm>
 
     <issueManagement>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,12 +20,12 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>5.1.0-RC1</version>
+        <version>5.1.0-RC1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-metrics-spec</artifactId>
     <packaging>pom</packaging>
     <name>MicroProfile Metrics Specification</name>
     <description>MicroProfile Metrics Specification :: Specification</description>
-    
+
 </project>

--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -13,7 +13,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-tck</artifactId>
-        <version>5.1.0-RC1</version>
+        <version>5.1.0-RC1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -39,7 +39,7 @@
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>

--- a/tck/optional/pom.xml
+++ b/tck/optional/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-tck</artifactId>
-        <version>5.1.0-RC1</version>
+        <version>5.1.0-RC1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -105,5 +105,5 @@
                 </executions>
             </plugin>
         </plugins>
-    </build>    
+    </build>
 </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,8 +20,8 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>5.1.0-RC1</version>
-        
+        <version>5.1.0-RC1.payara-p1</version>
+
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -56,5 +56,5 @@
                 </exclusions>
             </dependency>
         </dependencies>
-    </dependencyManagement>    
+    </dependencyManagement>
 </project>

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-tck</artifactId>
-        <version>5.1.0-RC1</version>
+        <version>5.1.0-RC1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This is to patch metrics version 5.1.0-RC1 and add changes to skip OSGI issue regarding java packages