### PR TITLE
FISH-7776: creating payara patch version for metrics 5.1.0

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -1,5 +1,6 @@
 -exportcontents: \
     org.eclipse.microprofile.*
+-noimportjava: true
 Import-Package: jakarta.enterprise.util.*;resolution:=optional, jakarta.inject.*;resolution:=optional, jakarta.interceptor.*;resolution:=optional, *
 Bundle-SymbolicName: org.eclipse.microprofile.metrics
 Bundle-Name: MicroProfile Metrics Bundle

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,23 +19,27 @@
     <parent>
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.0.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-metrics-api</artifactId>
     <name>MicroProfile Metrics API</name>
     <description>MicroProfile Metrics :: API</description>
 
+    <properties>
+        <bnd.baseline.continue.on.error>true</bnd.baseline.continue.on.error>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
@@ -103,5 +103,5 @@
  * </pre>
  *
  */
-@org.osgi.annotation.versioning.Version("5.1.0")
+@org.osgi.annotation.versioning.Version("5.1.0.payara-p1")
 package org.eclipse.microprofile.metrics.annotation;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/package-info.java
@@ -95,5 +95,5 @@
  * </code>
  * </pre>
  */
-@org.osgi.annotation.versioning.Version("5.1.0")
+@org.osgi.annotation.versioning.Version("5.1.0.payara-p1")
 package org.eclipse.microprofile.metrics;

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.eclipse.microprofile.metrics</groupId>
     <artifactId>microprofile-metrics-parent</artifactId>
-    <version>5.1.0</version>
+    <version>5.1.0.payara-p1</version>
     <packaging>pom</packaging>
     <name>MicroProfile Metrics</name>
     <description>Eclipse MicroProfile Metrics Feature :: Parent POM</description>
@@ -57,7 +57,7 @@
         <url>https://github.com/eclipse/microprofile-metrics</url>
         <connection>scm:git:https://github.com/eclipse/microprofile-metrics.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse/microprofile-metrics.git</developerConnection>
-        <tag>5.1.0</tag>
+        <tag>5.1.0.payara-p1</tag>
     </scm>
 
     <issueManagement>
@@ -88,7 +88,7 @@
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
-            
+
         </dependencies>
     </dependencyManagement>
 </project>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,12 +20,12 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.0.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-metrics-spec</artifactId>
     <packaging>pom</packaging>
     <name>MicroProfile Metrics Specification</name>
     <description>MicroProfile Metrics Specification :: Specification</description>
-    
+
 </project>

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -141,7 +141,7 @@ A full list of changes may be found on the link:https://github.com/eclipse/micro
 ** added ability for applications to add metrics to a custom scope (https://github.com/eclipse/microprofile-metrics/issues/677[677])
 ** added ability to use custom scope names with @RegistryScope annotation (https://github.com/eclipse/microprofile-metrics/issues/677[677])
 ** replaced @RegistryType with @RegistryScope (https://github.com/eclipse/microprofile-metrics/issues/677[677])
-** (5.1.0) @RegistryScope is now a qualifier  (https://github.com/eclipse/microprofile-metrics/issues/749[749])
+** (5.1.0.payara-p1) @RegistryScope is now a qualifier  (https://github.com/eclipse/microprofile-metrics/issues/749[749])
 
 === Other changes
 ** removed requirement to convert metrics to base units for Prometheus output

--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -13,7 +13,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-tck</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -39,13 +39,13 @@
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
 
-       
+
 
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/tck/optional/pom.xml
+++ b/tck/optional/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-tck</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -100,5 +100,5 @@
                 </executions>
             </plugin>
         </plugins>
-    </build>    
+    </build>
 </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,8 +20,8 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>5.1.0</version>
-        
+        <version>5.1.0.payara-p1</version>
+
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -56,5 +56,5 @@
                 </exclusions>
             </dependency>
         </dependencies>
-    </dependencyManagement>    
+    </dependencyManagement>
 </project>

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-tck</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Patching last tag for Metrics 5.1.0 an adding fixes to skip OSGi issues for JDK packages